### PR TITLE
Fix duplicate codex agent_ids and add tt kick for idle cleanup

### DIFF
--- a/skills/talking-stick/SKILL.md
+++ b/skills/talking-stick/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talking-stick
-description: Use when working in a repo that coordinates multiple agent harnesses with Talking Stick (`tt` / `talking-stick`), or when the user asks you to avoid parallel work, wait your turn, pass structured handoffs, or coordinate with Claude, Codex, Gemini, or OpenCode in the same workspace. Also use when a workspace contains a `.talking-stick/` marker or when the MCP tools `list_rooms`, `join_path`, `leave_room`, `wait_for_turn`, `heartbeat`, `release_stick`, `pass_stick`, `takeover_stick`, `get_room_state`, `get_room_events`, `add_note`, or `list_notes` are available.
+description: Use when working in a repo that coordinates multiple agent harnesses with Talking Stick (`tt` / `talking-stick`), or when the user asks you to avoid parallel work, wait your turn, pass structured handoffs, or coordinate with Claude, Codex, Gemini, or OpenCode in the same workspace. Also use when a workspace contains a `.talking-stick/` marker or when the MCP tools `list_rooms`, `join_path`, `leave_room`, `kick_member`, `wait_for_turn`, `heartbeat`, `release_stick`, `pass_stick`, `takeover_stick`, `get_room_state`, `get_room_events`, `add_note`, or `list_notes` are available.
 ---
 
 This skill teaches a harness how to behave in a Talking Stick workspace.
@@ -26,7 +26,7 @@ Do not use this skill for ordinary single-agent work in repos that are not using
 
 ### 1. Check that Talking Stick is actually available
 
-Prefer the Talking Stick MCP tools when they are available. If they are not available but the `tt` CLI is on `PATH`, use the CLI instead (`tt list`, `tt join`, `tt leave`, `tt wait`, `tt state`, `tt release`, `tt pass`, `tt assign`, `tt take`). Do not treat missing MCP tools alone as proof that coordination is unavailable.
+Prefer the Talking Stick MCP tools when they are available. If they are not available but the `tt` CLI is on `PATH`, use the CLI instead (`tt list`, `tt join`, `tt leave`, `tt kick`, `tt wait`, `tt state`, `tt release`, `tt pass`, `tt assign`, `tt take`). Do not treat missing MCP tools alone as proof that coordination is unavailable.
 
 If coordination is required and neither the MCP tools nor the `tt` CLI are available, say so briefly and ask the user whether they want to install or enable Talking Stick first. Do not pretend coordination is active.
 
@@ -178,12 +178,15 @@ In every other case: after `release_stick` or `pass_stick`, go straight back int
 
 If the operator tells you to drop out of coordination, call `leave_room` or `tt leave`. Rooms with no active members are deleted instead of kept as history, and long-idle rooms may be purged on later invocations.
 
+If the room state shows ghost members from past sessions whose processes are gone (visible as `inactive last seen ...` in `tt state`), call `kick_member` / `tt kick <agent_id>` to evict them. This is the right tool when liveness has already decided the target is dead — pass `force: true` only when the operator explicitly tells you to remove a still-active member.
+
 ## Recovery and Inspection
 
 Use these reads when you need context:
 
 - `list_rooms`: discover active rooms under a path
 - `leave_room`: explicitly remove your membership from a room
+- `kick_member`: evict an idle member whose process is gone (use `force: true` only on operator instruction)
 - `get_room_state`: authoritative current room projection
 - `get_room_events`: replay recent claims, releases, passes, and takeovers
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -148,6 +148,7 @@ Commands:
   tt list [path]
   tt join [path] [--force-new]
   tt leave [path]
+  tt kick <agent_id> [path] [--reason TEXT] [--force]
   tt wait [path] [--timeout 30s]
   tt try [path]
   tt state [path]

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -12,6 +12,7 @@ import type { ParsedCommand } from "./parser.js";
 import {
   handleEventsCommand,
   handleJoinCommand,
+  handleKickCommand,
   handleLeaveCommand,
   handleListCommand,
   handleStateCommand,
@@ -142,6 +143,15 @@ export const COMMAND_REGISTRY: CommandEntry[] = [
     usage: "tt leave [path]",
     description: "Leave this agent's room membership.",
     handler: ({ runtime, parsed }) => handleLeaveCommand(requireRuntime(runtime), parsed)
+  },
+  {
+    name: "kick",
+    needsRuntime: true,
+    startupMaintenance: true,
+    internal: false,
+    usage: "tt kick <agent_id> [path] [--reason TEXT] [--force]",
+    description: "Kick an idle member out of the room.",
+    handler: ({ runtime, parsed }) => handleKickCommand(requireRuntime(runtime), parsed)
   },
   {
     name: "state",

--- a/src/cli/room-commands.ts
+++ b/src/cli/room-commands.ts
@@ -6,6 +6,8 @@ import {
 } from "../index.js";
 import { stopGuardian } from "./guardian.js";
 import {
+  getStringOption,
+  hasOption,
   parseOptionalInteger,
   type ParsedCommand
 } from "./parser.js";
@@ -89,6 +91,41 @@ export function handleLeaveCommand(
     const memberLabel =
       result.remaining_members === 1 ? "member remains" : "members remain";
     return `Left ${session.canonical_path}; ${result.remaining_members} ${memberLabel}.`;
+  });
+}
+
+export function handleKickCommand(
+  runtime: Runtime,
+  parsed: ParsedCommand
+): void {
+  const [target, ...rest] = parsed.positionals;
+  if (!target) {
+    throw new Error("Missing required argument: <agent_id>");
+  }
+  const sessionParsed: ParsedCommand = { ...parsed, positionals: rest };
+  const identity = deriveCliIdentity(sessionParsed);
+  const session = resolveSessionForReads(runtime, sessionParsed, identity);
+  const result = runtime.commands.kickMember(identity, {
+    room_id: session.room_id,
+    target_agent_id: target,
+    force: hasOption(parsed, "force"),
+    reason: getStringOption(parsed, "reason")
+  });
+
+  const sessionPath = resolveCliSessionPath();
+  if (result.status === "room_deleted") {
+    removeCliSessionsForRoom(sessionPath, session.room_id);
+  } else {
+    removeCliSession(sessionPath, result.kicked_agent_id, session.room_id);
+  }
+
+  printResult(parsed, result, () => {
+    if (result.status === "room_deleted") {
+      return `Kicked ${result.kicked_agent_id}; room deleted.`;
+    }
+    const memberLabel =
+      result.remaining_members === 1 ? "member remains" : "members remain";
+    return `Kicked ${result.kicked_agent_id}; ${result.remaining_members} ${memberLabel}.`;
   });
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,7 @@ import type {
   GetRoomStateResult,
   HeartbeatResult,
   JoinPathResult,
+  KickMemberResult,
   LeaveRoomResult,
   ListNotesResult,
   ListRoomsInput,
@@ -29,6 +30,13 @@ export interface JoinPathCommandInput {
 
 export interface LeaveRoomCommandInput {
   room_id: string;
+}
+
+export interface KickMemberCommandInput {
+  room_id: string;
+  target_agent_id: string;
+  force?: boolean;
+  reason?: string;
 }
 
 export interface HeartbeatCommandInput {
@@ -101,6 +109,19 @@ export class TalkingStickCommands {
     return this.service.leaveRoom({
       agent_id: identity.agent_id,
       room_id: input.room_id
+    });
+  }
+
+  kickMember(
+    identity: DerivedIdentity,
+    input: KickMemberCommandInput
+  ): KickMemberResult {
+    return this.service.kickMember({
+      agent_id: identity.agent_id,
+      room_id: input.room_id,
+      target_agent_id: input.target_agent_id,
+      force: input.force,
+      reason: input.reason
     });
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,9 @@ import type { RoomState } from "./types.js";
 export type ProtocolErrorCode =
   | "room_not_found"
   | "unknown_member"
+  | "unknown_target"
+  | "target_active"
+  | "cannot_kick_self"
   | "invalid_handoff"
   | "stale_lease"
   | "turn_mismatch"

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -113,7 +113,8 @@ export function deriveMcpHarnessIdentity(
       processRef.pid,
       processRef.inspection,
       username,
-      hostId
+      hostId,
+      inspector
     );
     const agentId =
       options.agentId ?? harnessAgentId(signal.harness, sessionId, hostId, username);
@@ -201,7 +202,8 @@ export function deriveHarnessCliIdentity(
     processRef.pid,
     processRef.inspection,
     username,
-    hostId
+    hostId,
+    inspector
   );
 
   const agentId =
@@ -239,15 +241,60 @@ function resolveHarnessSessionId(
   parentPid: number,
   parentInspection: ProcessInspection | null | undefined,
   username: string,
-  hostId: string
+  hostId: string,
+  inspector: ProcessInspector
 ): string {
   if (signal.sessionId) return `harness:${signal.sessionId}`;
   const terminalId = resolveTerminalSessionId(env);
   if (terminalId) return terminalId;
+
+  const harnessRoot = findHarnessRootInAncestry(
+    signal.harness,
+    parentPid,
+    parentInspection,
+    inspector
+  );
+  if (harnessRoot) {
+    return `pid:${harnessRoot.pid}@${harnessRoot.startTime}`;
+  }
+
   if (parentInspection?.startTime) {
     return `pid:${parentPid}@${parentInspection.startTime}`;
   }
   return `userhost:${sanitizeIdentityComponent(username)}@${hostId}`;
+}
+
+// Walks the process ancestry (inclusive of startPid) looking for the deepest
+// process whose command matches the named harness. Anchoring session id to
+// that root keeps `tt` invocations stable whether they're spawned directly
+// by the harness (MCP subprocess) or through intermediate shells (CLI shell-out).
+function findHarnessRootInAncestry(
+  harness: HarnessCliHarness,
+  startPid: number,
+  startInspection: ProcessInspection | null | undefined,
+  inspector: ProcessInspector,
+  maxDepth = 10
+): { pid: number; startTime: string } | null {
+  let result: { pid: number; startTime: string } | null = null;
+  let currentPid: number | null | undefined = startPid;
+  let currentInspection = startInspection;
+  for (let i = 0; i < maxDepth; i++) {
+    if (currentPid == null || currentPid <= 1) break;
+    if (currentInspection === undefined) {
+      currentInspection = inspector.inspect(currentPid);
+    }
+    if (!currentInspection) break;
+    const label = deriveCommandLabel(currentInspection.command);
+    if (
+      HARNESS_COMMAND_MAPPING[label] === harness &&
+      currentInspection.startTime
+    ) {
+      result = { pid: currentPid, startTime: currentInspection.startTime };
+    }
+    currentPid = currentInspection.ppid ?? null;
+    currentInspection = undefined;
+  }
+  return result;
 }
 
 const TERMINAL_SESSION_ENV_VARS = [

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -91,6 +91,25 @@ export function createMcpServer(
   );
 
   server.registerTool(
+    "kick_member",
+    {
+      title: "Kick Member",
+      description:
+        "Remove an idle member from a room. Without force, only succeeds if the target's process is detected gone past the silence-grace window.",
+      inputSchema: {
+        room_id: z.string().min(1),
+        target_agent_id: z.string().min(1),
+        force: z.boolean().optional(),
+        reason: z.string().optional()
+      }
+    },
+    async (input, extra) =>
+      toolJson(() =>
+        commands.kickMember(resolveConnectionIdentity(extra.sessionId), input)
+      )
+  );
+
+  server.registerTool(
     "wait_for_turn",
     {
       title: "Wait For Turn",

--- a/src/service.ts
+++ b/src/service.ts
@@ -29,6 +29,8 @@ import type {
   HeartbeatResult,
   JoinPathInput,
   JoinPathResult,
+  KickMemberInput,
+  KickMemberResult,
   LeaveRoomInput,
   LeaveRoomResult,
   ListNotesInput,
@@ -322,6 +324,132 @@ export class TalkingStickService {
         room_id: input.room_id,
         canonical_path: room.canonical_path,
         remaining_members: remainingMembers.length
+      };
+    });
+  }
+
+  kickMember(input: KickMemberInput): KickMemberResult {
+    assertNonEmpty(input.agent_id, "agent_id");
+    assertNonEmpty(input.room_id, "room_id");
+    assertNonEmpty(input.target_agent_id, "target_agent_id");
+
+    if (input.target_agent_id === input.agent_id) {
+      throw new ProtocolError(
+        "cannot_kick_self",
+        "Use leave_room to remove yourself.",
+        { to_agent_id: input.target_agent_id }
+      );
+    }
+
+    const now = this.now();
+    const timestamp = now.toISOString();
+    this.purgeExpiredIdleRooms(now);
+
+    return withImmediateTransaction(this.db, () => {
+      const room = this.requireRoom(input.room_id);
+      this.touchMember(input.room_id, input.agent_id, timestamp);
+
+      const target = this.getMember(input.room_id, input.target_agent_id);
+      if (!target) {
+        throw new ProtocolError(
+          "unknown_target",
+          "Target agent is not a member of this room.",
+          { to_agent_id: input.target_agent_id }
+        );
+      }
+
+      if (!input.force) {
+        const liveness = this.getMemberProcessLiveness(target);
+        if (!this.isGonePersistent(target, liveness, now)) {
+          throw new ProtocolError(
+            "target_active",
+            "Target is still active. Pass force=true to kick anyway.",
+            { to_agent_id: input.target_agent_id }
+          );
+        }
+      }
+
+      const targetWasOwner = room.owner === input.target_agent_id;
+      const targetWasReservedFor = room.reserved_for === input.target_agent_id;
+
+      this.db
+        .prepare("DELETE FROM room_members WHERE room_id = ? AND agent_id = ?")
+        .run(input.room_id, input.target_agent_id);
+
+      this.appendEvent({
+        room_id: input.room_id,
+        turn_id: room.turn_id,
+        event_type: "kick",
+        from_agent_id: input.agent_id,
+        to_agent_id: input.target_agent_id,
+        handoff: null,
+        reason: input.reason ?? null,
+        created_at: timestamp
+      });
+
+      const remainingMembers = this.getMembers(input.room_id);
+      if (
+        remainingMembers.length === 0 ||
+        !remainingMembers.some((remaining) => this.isMemberActive(remaining, now))
+      ) {
+        this.deleteRoom(input.room_id);
+        return {
+          status: "room_deleted",
+          room_id: input.room_id,
+          canonical_path: room.canonical_path,
+          kicked_agent_id: input.target_agent_id,
+          remaining_members: 0,
+          target_was_owner: targetWasOwner,
+          target_was_reserved_for: targetWasReservedFor
+        };
+      }
+
+      const nextOwner = targetWasOwner ? null : room.owner;
+      const nextReservedFor = targetWasReservedFor ? null : room.reserved_for;
+      const nextState =
+        room.state === "closed"
+          ? "closed"
+          : nextOwner
+            ? "owned"
+            : nextReservedFor
+              ? "reserved"
+              : "idle";
+
+      this.db
+        .prepare(
+          `
+          UPDATE path_rooms
+          SET owner = ?,
+              reserved_for = ?,
+              pending_handoff_event_seq = ?,
+              lease_id = ?,
+              lease_expires_at = ?,
+              claim_expires_at = ?,
+              state = ?,
+              updated_at = ?
+          WHERE room_id = ?
+        `
+        )
+        .run(
+          nextOwner,
+          nextReservedFor,
+          targetWasOwner ? null : room.pending_handoff_event_seq,
+          targetWasOwner ? null : room.lease_id,
+          targetWasOwner ? null : room.lease_expires_at,
+          targetWasReservedFor ? null : room.claim_expires_at,
+          nextState,
+          timestamp,
+          input.room_id
+        );
+
+      return {
+        status: "kicked",
+        room_id: input.room_id,
+        canonical_path: room.canonical_path,
+        kicked_agent_id: input.target_agent_id,
+        remaining_members: remainingMembers.length,
+        target_was_owner: targetWasOwner,
+        target_was_reserved_for: targetWasReservedFor
       };
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,7 @@ export interface RoomEvent {
   event_id: string;
   room_id: string;
   turn_id: number;
-  event_type: "claim" | "release" | "pass" | "takeover" | "close";
+  event_type: "claim" | "release" | "pass" | "takeover" | "close" | "kick";
   from_agent_id: AgentId | null;
   to_agent_id: AgentId | null;
   handoff: Handoff | null;
@@ -130,6 +130,24 @@ export interface LeaveRoomResult {
   room_id: string;
   canonical_path: string;
   remaining_members: number;
+}
+
+export interface KickMemberInput {
+  agent_id: AgentId;
+  room_id: string;
+  target_agent_id: AgentId;
+  force?: boolean;
+  reason?: string;
+}
+
+export interface KickMemberResult {
+  status: "kicked" | "room_deleted";
+  room_id: string;
+  canonical_path: string;
+  kicked_agent_id: AgentId;
+  remaining_members: number;
+  target_was_owner: boolean;
+  target_was_reserved_for: boolean;
 }
 
 export interface WaitForTurnInput {

--- a/tests/identity.test.ts
+++ b/tests/identity.test.ts
@@ -412,6 +412,66 @@ describe("CLI and MCP identity unification", () => {
     expect(mcpIdentity.process_metadata.session_kind).toBe("mcp_harness");
   });
 
+  test("unifies CLI and MCP codex identities via ancestry when CODEX_THREAD_ID is absent", () => {
+    // Codex root process at pid 100; codex's MCP subprocess is a direct child
+    // (parentPid=100). A `tt` CLI invocation goes codex → bash → tt, so its
+    // parentPid is the bash subshell (200), not codex. Without CODEX_THREAD_ID,
+    // both must still resolve to the same agent_id by anchoring to codex's pid.
+    const inspector = fakeInspector({
+      100: { startTime: "Tue Apr 28 19:00:00 2026", command: "codex", ppid: 1 },
+      200: { startTime: "Tue Apr 28 19:35:00 2026", command: "bash", ppid: 100 }
+    });
+    const env = { CODEX_MANAGED_BY_NPM: "1" };
+
+    const mcpIdentity = deriveMcpHarnessIdentity({
+      env,
+      username: "alice",
+      parentPid: 100,
+      hostId: "test-host",
+      inspector
+    });
+
+    const cliIdentity = deriveHarnessCliIdentity({
+      env,
+      username: "alice",
+      parentPid: 200,
+      hostId: "test-host",
+      inspector
+    });
+
+    expect(mcpIdentity.agent_id).toMatch(/^codex:[0-9a-f]{8}$/);
+    expect(cliIdentity!.agent_id).toBe(mcpIdentity.agent_id);
+  });
+
+  test("a second `tt` shell-out from the same codex session reuses the agent_id", () => {
+    // Same codex root, two distinct bash subshells with different pids.
+    // Anchoring the session id to codex's pid means both `tt` invocations
+    // produce the same agent_id.
+    const inspector = fakeInspector({
+      100: { startTime: "Tue Apr 28 19:00:00 2026", command: "codex", ppid: 1 },
+      200: { startTime: "Tue Apr 28 19:35:00 2026", command: "bash", ppid: 100 },
+      300: { startTime: "Tue Apr 28 22:12:00 2026", command: "bash", ppid: 100 }
+    });
+    const env = { CODEX_MANAGED_BY_NPM: "1" };
+
+    const first = deriveHarnessCliIdentity({
+      env,
+      username: "alice",
+      parentPid: 200,
+      hostId: "test-host",
+      inspector
+    });
+    const second = deriveHarnessCliIdentity({
+      env,
+      username: "alice",
+      parentPid: 300,
+      hostId: "test-host",
+      inspector
+    });
+
+    expect(first!.agent_id).toBe(second!.agent_id);
+  });
+
   test("MCP path falls back to ancestry-based id when no harness env is set (backwards compat)", () => {
     const inspector = fakeInspector({
       42: { startTime: "Thu Apr 23 14:15:00 2026", command: "some-other-harness --mcp" }

--- a/tests/mcp-smoke.test.ts
+++ b/tests/mcp-smoke.test.ts
@@ -42,6 +42,7 @@ describe("mcp smoke coverage", () => {
       "list_rooms",
       "join_path",
       "leave_room",
+      "kick_member",
       "wait_for_turn",
       "heartbeat",
       "release_stick",

--- a/tests/talking-stick.test.ts
+++ b/tests/talking-stick.test.ts
@@ -1730,6 +1730,236 @@ describe("talking-stick vertical slice", () => {
 
     expect(codexAfterExpiry.status).toBe("not_yet");
   });
+
+  test("kick_member removes a gone member and records a kick event", async () => {
+    const harness = createHarness({ policy: { heartbeatIntervalMs: 1_000 } });
+    const project = createProject(harness.tempRoot);
+    const claudeProcess = harness.processRegistry.create("claude");
+    const codexProcess = harness.processRegistry.create("codex");
+
+    const claudeJoin = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project,
+      process_metadata: claudeProcess
+    });
+    harness.service.joinPath({
+      agent_id: "codex:test",
+      context_path: project,
+      process_metadata: codexProcess
+    });
+
+    harness.processRegistry.markGone(codexProcess);
+    harness.clock.advance(2_001);
+
+    const result = harness.service.kickMember({
+      room_id: claudeJoin.room_id,
+      agent_id: "claude:test",
+      target_agent_id: "codex:test",
+      reason: "stale codex session"
+    });
+
+    expect(result.status).toBe("kicked");
+    expect(result.kicked_agent_id).toBe("codex:test");
+    expect(result.remaining_members).toBe(1);
+    expect(result.target_was_owner).toBe(false);
+
+    const state = harness.service.getRoomState({ room_id: claudeJoin.room_id });
+    expect(state.members.map((m) => m.agent_id)).toEqual(["claude:test"]);
+
+    const events = harness.service.getRoomEvents({
+      room_id: claudeJoin.room_id,
+      after_event_seq: 0
+    });
+    const kickEvent = events.find((e) => e.event_type === "kick");
+    expect(kickEvent).toBeDefined();
+    expect(kickEvent?.from_agent_id).toBe("claude:test");
+    expect(kickEvent?.to_agent_id).toBe("codex:test");
+    expect(kickEvent?.reason).toBe("stale codex session");
+  });
+
+  test("kick_member rejects an active target without force", async () => {
+    const harness = createHarness();
+    const project = createProject(harness.tempRoot);
+    const claudeProcess = harness.processRegistry.create("claude");
+    const codexProcess = harness.processRegistry.create("codex");
+
+    const claudeJoin = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project,
+      process_metadata: claudeProcess
+    });
+    harness.service.joinPath({
+      agent_id: "codex:test",
+      context_path: project,
+      process_metadata: codexProcess
+    });
+
+    expect(() =>
+      harness.service.kickMember({
+        room_id: claudeJoin.room_id,
+        agent_id: "claude:test",
+        target_agent_id: "codex:test"
+      })
+    ).toThrowProtocolError("target_active");
+  });
+
+  test("kick_member with force removes an active target", async () => {
+    const harness = createHarness();
+    const project = createProject(harness.tempRoot);
+    const claudeProcess = harness.processRegistry.create("claude");
+    const codexProcess = harness.processRegistry.create("codex");
+
+    const claudeJoin = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project,
+      process_metadata: claudeProcess
+    });
+    harness.service.joinPath({
+      agent_id: "codex:test",
+      context_path: project,
+      process_metadata: codexProcess
+    });
+
+    const result = harness.service.kickMember({
+      room_id: claudeJoin.room_id,
+      agent_id: "claude:test",
+      target_agent_id: "codex:test",
+      force: true
+    });
+
+    expect(result.status).toBe("kicked");
+    expect(result.remaining_members).toBe(1);
+  });
+
+  test("kick_member clears ownership when the target was the owner", async () => {
+    const harness = createHarness({ policy: { heartbeatIntervalMs: 1_000 } });
+    const project = createProject(harness.tempRoot);
+    const codexProcess = harness.processRegistry.create("codex");
+    const claudeProcess = harness.processRegistry.create("claude");
+
+    const codexJoin = harness.service.joinPath({
+      agent_id: "codex:test",
+      context_path: project,
+      process_metadata: codexProcess
+    });
+    harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project,
+      process_metadata: claudeProcess
+    });
+
+    asYourTurn(
+      await harness.service.waitForTurn({
+        agent_id: "codex:test",
+        room_id: codexJoin.room_id,
+        max_wait_ms: 0
+      })
+    );
+
+    harness.processRegistry.markGone(codexProcess);
+    harness.clock.advance(2_001);
+
+    const result = harness.service.kickMember({
+      room_id: codexJoin.room_id,
+      agent_id: "claude:test",
+      target_agent_id: "codex:test"
+    });
+
+    expect(result.target_was_owner).toBe(true);
+    const state = harness.service.getRoomState({ room_id: codexJoin.room_id });
+    expect(state.room.owner).toBeNull();
+    expect(state.room.state).toBe("idle");
+  });
+
+  test("kick_member deletes the room when no active members remain", async () => {
+    const harness = createHarness({ policy: { heartbeatIntervalMs: 1_000 } });
+    const project = createProject(harness.tempRoot);
+    const claudeProcess = harness.processRegistry.create("claude");
+    const codexProcess = harness.processRegistry.create("codex");
+
+    const claudeJoin = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project,
+      process_metadata: claudeProcess
+    });
+    harness.service.joinPath({
+      agent_id: "codex:test",
+      context_path: project,
+      process_metadata: codexProcess
+    });
+
+    // Both processes are gone past the silence grace; the caller can still kick
+    // (touchMember refreshes their last_seen_at), and the room collapses since
+    // nobody else remains alive.
+    harness.processRegistry.markGone(codexProcess);
+    harness.clock.advance(2_001);
+    harness.processRegistry.markGone(claudeProcess);
+
+    const result = harness.service.kickMember({
+      room_id: claudeJoin.room_id,
+      agent_id: "claude:test",
+      target_agent_id: "codex:test"
+    });
+
+    expect(result.status).toBe("room_deleted");
+    expect(result.remaining_members).toBe(0);
+    expect(() =>
+      harness.service.getRoomState({ room_id: claudeJoin.room_id })
+    ).toThrowProtocolError("room_not_found");
+  });
+
+  test("kick_member rejects self-kick", async () => {
+    const harness = createHarness();
+    const project = createProject(harness.tempRoot);
+    const join = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project
+    });
+
+    expect(() =>
+      harness.service.kickMember({
+        room_id: join.room_id,
+        agent_id: "claude:test",
+        target_agent_id: "claude:test"
+      })
+    ).toThrowProtocolError("cannot_kick_self");
+  });
+
+  test("kick_member rejects a non-member caller", async () => {
+    const harness = createHarness();
+    const project = createProject(harness.tempRoot);
+    const join = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project
+    });
+
+    expect(() =>
+      harness.service.kickMember({
+        room_id: join.room_id,
+        agent_id: "stranger:test",
+        target_agent_id: "claude:test",
+        force: true
+      })
+    ).toThrowProtocolError("unknown_member");
+  });
+
+  test("kick_member rejects an unknown target", async () => {
+    const harness = createHarness();
+    const project = createProject(harness.tempRoot);
+    const join = harness.service.joinPath({
+      agent_id: "claude:test",
+      context_path: project
+    });
+
+    expect(() =>
+      harness.service.kickMember({
+        room_id: join.room_id,
+        agent_id: "claude:test",
+        target_agent_id: "ghost:test",
+        force: true
+      })
+    ).toThrowProtocolError("unknown_target");
+  });
 });
 
 function createHarness(


### PR DESCRIPTION
## Summary

- **Anchor harness session id to harness root pid via ancestry walk.** When a harness env signal (e.g. `CODEX_MANAGED_BY_NPM=1`) is detected without an explicit session id, walk up from the immediate parent to find the harness's root process and use its `pid+startTime` as the session anchor. Previously each `tt` shell-out from a codex session used the bash subshell's pid, producing a fresh agent_id per invocation and stacking duplicate codex members in the same room.
- **`tt kick` / `kick_member`.** New CLI command and MCP tool to evict a member from a room. Default behavior refuses unless the target's process is detected gone past the existing silence-grace window; `--force` / `force: true` bypasses the check. Records a `kick` event so other agents see the eviction. Skill doc updated.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 222 passed (was 214; +2 identity regression tests, +8 service kick tests, +1 mcp-smoke tool list update)
- [x] `npm run build`