### PR TITLE
Plan CLI-only Talking Stick coordination

### DIFF
--- a/docs/plans/2026-05-05-cli-only-coordination.md
+++ b/docs/plans/2026-05-05-cli-only-coordination.md
@@ -126,16 +126,20 @@ Implementation shape:
 - Reuse the existing harness config discovery/write helpers and adapter-level install shape. Removal should be the inverse of install, not a second parser/matcher.
 - Delete MCP add planning after cleanup support lands, but keep the adapter-owned stale-entry removal path.
 - Add fixture tests for each supported harness proving a stale canonical Talking Stick MCP entry is removed, a neighboring unrelated MCP entry survives, and a hand-edited Talking Stick-looking entry survives.
+- The audit log lives in a dedicated `${TALKING_STICK_DATA_DIR}/update-migrations.log`, not the general maintenance log. Update migrations are infrequent destructive events that operators may need to grep for after the fact ("why did my MCP entry disappear?"); mixing them with daily startup chatter makes that grep noisy and the destructive history harder to see at a glance. Format: one JSON line per migration run with `{ ts, package_version_from, package_version_to, harness, config_path, action, server_name }`.
 
-### OOB Messaging
+### OOB Messaging And Ambient Receive
 
 OOB stays on the existing `room_events` / `message_sent` substrate, but all live receive UX is CLI-based.
 
+The recommended ambient consumer is **`tt events --follow --target self --json`**, not `tt msg recv --follow`. The event stream surfaces direct messages, broadcasts, **and** turn passes/reservations on a single ordered feed. A messages-only receiver silently misses the moment another agent passes you the stick — exactly the gap that motivated this section. The skill teaches the unified consumer in §2 (start it right after `tt join`) and references it from §4.5.
+
 Required receive contract:
 
-- `tt msg recv --follow --target self --json` emits one JSON event per line.
+- `tt events --follow --target self --json` emits one JSON event per line for messages, broadcasts, and turn handoffs targeting the caller.
 - It exits cleanly on SIGTERM/SIGHUP and writes the cursor to stderr as today.
-- `tt msg recv --wait --after <cursor> --json` exits after the next matching batch for harnesses that cannot monitor long-running stdout.
+- `tt events --wait --after <cursor> --target self --json` exits after the next matching batch for harnesses that cannot monitor long-running stdout.
+- `tt msg recv --follow` and `tt msg recv --wait` remain available as messages-only feeds for harnesses that explicitly want the narrower stream, but the skill marks them as fallback rather than primary.
 - First launch starts at the room tail unless `--after` is explicit, avoiding historical replay.
 - Direct messages and room broadcasts are included for `target=self`; the caller's own broadcasts are excluded.
 
@@ -212,3 +216,5 @@ Before merging the code-removal PR:
 3. Update/first-run maintenance must automatically remove Talking Stick-owned stale MCP config entries across all supported harnesses, and `tt uninstall` should run the same cleanup. It must not touch unrelated harness config.
 4. Stale MCP cleanup must reuse each harness adapter's install resolver as the inverse operation. Do not reimplement config matching separately.
 5. The diff walker can read SQLite/internal state directly for its hot watch path because it ships in this package; user-facing annotations still go through `tt msg send` or `tt notes add`.
+6. The skill's primary ambient receiver is `tt events --follow --target self --json`, not `tt msg recv --follow`. A messages-only consumer silently misses turn passes/reservations and forces harnesses back to polling for the most load-bearing event in the protocol. The unified event stream is the recommended primary path; `tt msg recv` becomes a narrower fallback.
+7. Cleanup audit lives in a dedicated `update-migrations.log`, not folded into general maintenance logging. Update migrations are infrequent destructive events; isolating them keeps "why did my MCP entry disappear" answerable by a single `cat`.

--- a/docs/plans/2026-05-05-cli-only-coordination.md
+++ b/docs/plans/2026-05-05-cli-only-coordination.md
@@ -1,0 +1,214 @@
+# CLI-Only Coordination And MCP Removal
+
+**Status:** draft by `codex:d4bc2492`, incorporating Claude OOB review. **Branch:** `oob-identity-fix-plan`.
+
+## Why This Change
+
+Out-of-band messaging exposed a deeper problem: Talking Stick has two harness integration paths, CLI and MCP, and they do not share the same process context. A message addressed to the MCP-side agent id can disappear from `tt msg recv --target self` if the CLI-side resolver produces a different id. Fixing one resolver bug helps, but keeping MCP in the active path preserves the same class of failure.
+
+The new direction is simpler: **the `tt` CLI is the only harness contract.** Agents coordinate by running `tt` commands. MCP is removed from install, docs, skills, tests, and eventually package dependencies. The SQLite-backed service/core can stay as internal implementation; the public automation surface is `tt`.
+
+## Goals
+
+- Make every agent workflow expressible through CLI commands: `tt join`, `tt wait`, `tt release`, `tt assign`, `tt take`, `tt state`, `tt events`, `tt notes`, and `tt msg`.
+- Make OOB messaging CLI-first: `tt msg recv --follow` for live stdout consumers, `tt msg recv --wait --after <cursor>` for process-completion consumers.
+- Remove MCP registration from `tt install` and remove `tt mcp` as a supported command.
+- Automatically remove stale Talking Stick MCP registrations from every supported harness during update/first-run migration.
+- Update the bundled skill so harnesses prefer CLI even when MCP tools exist in older installations.
+- Replace MCP smoke coverage with real child-process CLI smoke coverage, including SIGTERM/cursor behavior.
+- Keep long turns safe by making the CLI-owned lease guardian a first-class contract of `tt wait` / `tt take`.
+- Preserve human-friendly CLI defaults: human shells get readable text unless `--json` is explicit; harness-detected shells get JSON where machine output is expected.
+
+## Non-Goals
+
+- No backward compatibility promise for MCP users beyond automatic cleanup of stale Talking Stick-owned MCP registrations. This is an intentional breaking simplification.
+- No plugin requirement. Plugins may later wrap the CLI, but v1 must work with subprocesses and stdout.
+- No daemon. The existing SQLite service and `tt guard` process model remain enough; do not reintroduce a long-running automation server under another name.
+- No change to the single-writer room semantics.
+
+## Target Architecture
+
+### Public Surface
+
+`tt` is the public API. Harnesses call it through shell/exec facilities and parse JSON when they need structured output.
+
+Core command mapping:
+
+| Need | CLI |
+|---|---|
+| Join room | `tt join [path] --json` |
+| Wait/claim | `tt wait [path] --timeout 110s --json` |
+| Probe | `tt try [path] --json` |
+| Release | `tt release [path] --stdin` |
+| Assign specific next holder | `tt assign <agent_id> [path] --stdin` |
+| Operator takeover | `tt take [path] --operator-requested --reason ... --json` |
+| State | `tt state [path] --json` |
+| Events | `tt events [path] --after N --target any --json` |
+| Notes | `tt notes add/list ... --json` |
+| Send OOB | `tt msg send <recipient|room> <body...> --json` |
+| Receive OOB | `tt msg recv --follow --target self --json` |
+
+The skill should teach these exact commands. It should not mention `join_path`, `wait_for_turn`, `release_stick`, `send_message`, or any MCP tool as a preferred path.
+
+Successful `tt wait` and `tt take` calls must start or repair the internal `tt guard` lease guardian and return its `guardian_pid` in JSON. That guardian is not a harness API; it is the CLI's mechanism for keeping long turns alive after the `tt wait` process exits.
+
+### Internal Surface
+
+Keep `TalkingStickService` / `TalkingStickCommands` as internal TypeScript modules backing the CLI. They are not the harness API. The command layer owns input parsing, identity, JSON/text output policy, guardian spawning, and child-process behavior.
+
+The CLI-only rule applies to external harness coordination. Same-package processes may still call internal modules when they are part of Talking Stick itself. The diff walker should use direct SQLite or internal service reads for its hot attribution/watch path, then use normal CLI commands for rare outward actions such as sending an annotation message or adding a note.
+
+### Holder Lease Guardian
+
+Claude's main review concern is load-bearing: if `tt wait` exits and no process continues heartbeating, a holder doing a long edit can time out and look stale. The current `tt wait` path already has the right shape: it spawns internal `tt guard` and records the guardian in the CLI session. The CLI-only migration should make that behavior explicit and tested, not incidental.
+
+Required behavior:
+
+- `tt wait --json` returning `your_turn` includes `guardian_pid`.
+- `tt take --json` returning success includes `guardian_pid`.
+- If the caller already owns the turn and the old guardian is gone, `tt wait` repairs it by spawning a replacement.
+- `tt release`, `tt pass`, and `tt assign` do not require the original `tt wait` process to still exist; they rely on the persisted CLI session and identity.
+- Tests kill the guardian and prove the next owner command either repairs or reports the problem clearly.
+
+This avoids a harness-level `tt heartbeat` timer and avoids wrapping all work in a daemon-like `tt hold` command.
+
+### Process Cost
+
+CLI-only coordination pays a Node startup and SQLite-open cost for every command. That is acceptable for `tt wait` cycles, handoffs, notes, and OOB messages. Do not answer this by adding a long-running daemon unless the operator explicitly reverses the CLI-only decision; a daemon would recreate the same dual-context class of failure that led to removing MCP.
+
+### Identity
+
+With MCP removed, issue #19 becomes a CLI-only identity reliability issue instead of a CLI-vs-MCP comparison. The resolver still needs to be stable across repeated shell-outs from the same harness:
+
+1. `TT_HARNESS_AGENT_ID` wins when explicitly exported.
+2. Harness-provided stable ids win next (`CODEX_THREAD_ID`, `OPENCODE_RUN_ID`, similar).
+3. Harness-root ancestry wins before terminal ids for no-session-id harnesses like Claude Code.
+4. Terminal ids (`ITERM_SESSION_ID`, `CMUX_TAB_ID`, etc.) are fallback only after no harness root can be found.
+5. Human fallback remains `human:<username>`.
+
+Live receivers should either use the resolved harness id directly or run under `TT_HARNESS_AGENT_ID=<agent_id>` when a wrapper has already joined a room as that id.
+
+### Install
+
+`tt install` should become a skill/bootstrap installer, not an MCP installer. Update paths should also clean up old MCP registrations automatically so existing harnesses stop seeing the removed integration surface.
+
+Proposed behavior:
+
+- `tt install <harness...> | --all [--print] [--copy] [--link]`: install/update the bundled skill only.
+- Remove `tt install-skill` / `tt uninstall-skill` once `tt install` owns skill installation. There is no compatibility requirement to keep parallel install verbs.
+- `tt uninstall`: remove the skill install and Talking Stick-owned stale MCP config entries.
+- Remove MCP config writes for Claude, Codex, Gemini, and OpenCode.
+- Remove `DEFAULT_SERVER_COMMAND = ["tt", "mcp"]`.
+- Remove native `harness mcp add/remove` command planning.
+
+### Update-Time MCP Cleanup
+
+Backward compatibility means removing the stale broken path, not keeping it alive. A user who updates from an MCP-capable version should not have to manually edit every harness config.
+
+Required behavior:
+
+- The package update lifecycle runs a cleanup pass when the package manager executes install/update scripts.
+- `tt self-update` in versions that know about this migration runs the cleanup pass after the package manager completes.
+- The first normal `tt` invocation after a package version change runs the same cleanup pass, covering users who update from an older `tt self-update`, skip lifecycle scripts, or use `npm update -g`, `mise`, `pnpm`, or another manager.
+- Cleanup targets all supported harness config locations, not only the currently detected harness. Old entries in Claude, Codex, Gemini, and OpenCode should be removed together.
+- The cleanup is idempotent and silent when nothing changes. If it modifies config during an interactive human CLI run, print a concise summary; harness JSON commands should not get noisy text.
+- Always append an audit entry for removals with harness, config path, and removed server key/name so an operator can inspect why an MCP entry disappeared.
+- Only remove Talking Stick-owned MCP entries by strict inverse-of-install matching: canonical server name/key `talking-stick` plus the exact command/args shape this installer previously wrote for that harness.
+- Leave hand-edited or custom entries alone, even if they mention `talking-stick`, when the name/key or command/args no longer match the canonical installed shape.
+- Do not remove unrelated MCP servers or unrelated harness settings.
+- Config writes remain atomic and should preserve formatting where the existing installer machinery already can.
+
+Implementation shape:
+
+- Add `removeStaleMcpRegistrations({ harnesses: "all", reason: "update" })` in the install/maintenance layer.
+- Track the last package version that completed migration in the Talking Stick data dir, separate from room state, so startup can cheaply decide whether to run it.
+- Expose a non-interactive internal cleanup entrypoint that package lifecycle scripts can call without joining rooms or emitting harness JSON.
+- Reuse the existing harness config discovery/write helpers and adapter-level install shape. Removal should be the inverse of install, not a second parser/matcher.
+- Delete MCP add planning after cleanup support lands, but keep the adapter-owned stale-entry removal path.
+- Add fixture tests for each supported harness proving a stale canonical Talking Stick MCP entry is removed, a neighboring unrelated MCP entry survives, and a hand-edited Talking Stick-looking entry survives.
+
+### OOB Messaging
+
+OOB stays on the existing `room_events` / `message_sent` substrate, but all live receive UX is CLI-based.
+
+Required receive contract:
+
+- `tt msg recv --follow --target self --json` emits one JSON event per line.
+- It exits cleanly on SIGTERM/SIGHUP and writes the cursor to stderr as today.
+- `tt msg recv --wait --after <cursor> --json` exits after the next matching batch for harnesses that cannot monitor long-running stdout.
+- First launch starts at the room tail unless `--after` is explicit, avoiding historical replay.
+- Direct messages and room broadcasts are included for `target=self`; the caller's own broadcasts are excluded.
+
+## Implementation Sequence
+
+### Stage 1 — Skill And Plan
+
+This PR:
+
+- Add this plan.
+- Update `skills/talking-stick/SKILL.md` to be CLI-only.
+- Remove MCP-first language from the OOB skill section.
+- Keep source code unchanged except docs/skill, so Claude can review direction before the destructive code pass.
+
+### Stage 2 — CLI Identity Hardening
+
+- Change resolver precedence so harness-root ancestry beats terminal-session fallback when a harness env marker exists but no stable session id is present.
+- Add tests for Claude CLI shell-out matching repeated invocations from the same harness root.
+- Add child-process tests proving `tt msg recv --target self` receives a message addressed to the active CLI member without `TT_HARNESS_AGENT_ID`.
+- Add guardian tests proving `tt wait` / `tt take` return a live `guardian_pid`, and that a subsequent `tt wait` repairs a dead guardian for an existing owner.
+- Keep `TT_HARNESS_AGENT_ID` override as the explicit escape hatch.
+
+### Stage 3 — Installer De-MCP
+
+- Change `tt install` / `tt uninstall` to manage skill installs plus cleanup of stale Talking Stick MCP entries.
+- Add automatic stale MCP cleanup to package update lifecycle, `tt self-update`, and first-run-after-version-change startup maintenance.
+- Delete MCP add planning from `src/install.ts`; keep only the adapter-owned inverse-of-install removal/migration code needed to clean stale Talking Stick-owned entries.
+- Remove stale Talking Stick MCP entries during `tt uninstall` too; do not remove unrelated harness config.
+- Update README install instructions.
+- Add tests showing `tt install --all` skips missing harnesses silently and does not write MCP config.
+- Add update-migration tests covering all supported harnesses, idempotency, and preservation of unrelated MCP servers.
+
+### Stage 4 — Remove MCP Server Surface
+
+- Remove `tt mcp` from the command registry and help.
+- Delete `src/mcp-server.ts` and MCP-specific tests.
+- Delete `src/server.ts` unless another stdio entrypoint still needs it.
+- Remove `@modelcontextprotocol/sdk` from `package.json`.
+- Remove MCP exports from `src/index.ts`.
+- Replace MCP smoke tests with CLI child-process smoke tests covering join/wait/release/msg/notes.
+
+### Stage 5 — Docs And Release Notes
+
+- Rewrite README around CLI-first coordination.
+- Update `docs/receive-consumer-contract.md` to describe CLI subprocess consumers, not MCP wrappers.
+- Update older OOB plan docs with a superseded note pointing here.
+- Add a release note marking the change as breaking.
+
+### Stage 6 — Live Dogfood
+
+Before merging the code-removal PR:
+
+- Start Claude receiver with `tt msg recv --follow --target self --json`.
+- Start Codex receiver the same way.
+- Send direct and broadcast messages both directions.
+- Verify `tt wait --timeout 110s --json`, `tt release --stdin`, and `tt assign <agent>` work from harness shell-outs.
+- Verify no MCP subprocess is required for the room to operate.
+
+## Risks
+
+- **Harnesses without reliable shell execution.** If a harness cannot run `tt`, it cannot use Talking Stick. That is acceptable under the new direction; the installer/skill should say so clearly.
+- **Lease expiry during long turns.** If guardian spawning regresses, long owner turns can time out after `tt wait` exits. Treat guardian behavior as required CLI surface and cover it with child-process tests.
+- **Per-command process cost.** Repeated `tt` shell-outs pay Node startup and SQLite open cost. Accept this as the cost of a single CLI context; do not reintroduce a daemon/MCP-like server without an explicit operator change.
+- **Long-running receiver lifecycle.** Some harnesses cannot monitor stdout from a running child. Keep `--wait --after` as the supported fallback.
+- **Skill drift.** Installed skills may still have old MCP-first text. Human CLI startup sync helps file-based installs, but Gemini registry installs still need `tt install gemini`.
+- **Config cleanup safety.** Automatic update cleanup can be destructive if the matcher is too broad. Match only canonical inverse-of-install Talking Stick MCP entries and test with unrelated neighboring MCP servers plus hand-edited Talking Stick-looking entries in every harness fixture.
+- **Large test deletion.** Removing MCP tests can accidentally reduce protocol coverage. Replace them with CLI tests before deleting assertions.
+- **Diff walker hot path.** A live watcher should not spawn `tt` for every file event. Use direct SQLite/internal reads for hot attribution and CLI subprocesses only for outward coordination events.
+
+## Decisions From Claude Review
+
+1. `tt install` fully replaces `tt install-skill`; remove the parallel verb in the destructive code pass.
+2. `tt mcp` is removed immediately rather than kept as a migration shim.
+3. Update/first-run maintenance must automatically remove Talking Stick-owned stale MCP config entries across all supported harnesses, and `tt uninstall` should run the same cleanup. It must not touch unrelated harness config.
+4. Stale MCP cleanup must reuse each harness adapter's install resolver as the inverse operation. Do not reimplement config matching separately.
+5. The diff walker can read SQLite/internal state directly for its hot watch path because it ships in this package; user-facing annotations still go through `tt msg send` or `tt notes add`.

--- a/docs/plans/2026-05-05-cli-only-coordination.md
+++ b/docs/plans/2026-05-05-cli-only-coordination.md
@@ -11,7 +11,7 @@ The new direction is simpler: **the `tt` CLI is the only harness contract.** Age
 ## Goals
 
 - Make every agent workflow expressible through CLI commands: `tt join`, `tt wait`, `tt release`, `tt assign`, `tt take`, `tt state`, `tt events`, `tt notes`, and `tt msg`.
-- Make OOB messaging CLI-first: `tt msg recv --follow` for live stdout consumers, `tt msg recv --wait --after <cursor>` for process-completion consumers.
+- Make ambient receive CLI-first: `tt events --follow --target self --json` for live stdout consumers, `tt events --wait --after <cursor> --target self --json` for process-completion consumers, and `tt msg recv` only for messages-only consumers.
 - Remove MCP registration from `tt install` and remove `tt mcp` as a supported command.
 - Automatically remove stale Talking Stick MCP registrations from every supported harness during update/first-run migration.
 - Update the bundled skill so harnesses prefer CLI even when MCP tools exist in older installations.
@@ -46,7 +46,8 @@ Core command mapping:
 | Events | `tt events [path] --after N --target any --json` |
 | Notes | `tt notes add/list ... --json` |
 | Send OOB | `tt msg send <recipient|room> <body...> --json` |
-| Receive OOB | `tt msg recv --follow --target self --json` |
+| Ambient receive | `tt events --follow --target self --json` |
+| Messages-only receive | `tt msg recv --follow --target self --json` |
 
 The skill should teach these exact commands. It should not mention `join_path`, `wait_for_turn`, `release_stick`, `send_message`, or any MCP tool as a preferred path.
 
@@ -158,7 +159,8 @@ This PR:
 
 - Change resolver precedence so harness-root ancestry beats terminal-session fallback when a harness env marker exists but no stable session id is present.
 - Add tests for Claude CLI shell-out matching repeated invocations from the same harness root.
-- Add child-process tests proving `tt msg recv --target self` receives a message addressed to the active CLI member without `TT_HARNESS_AGENT_ID`.
+- Add child-process tests proving `tt events --target self` receives direct messages and turn handoffs addressed to the active CLI member without `TT_HARNESS_AGENT_ID`.
+- Keep narrower coverage proving `tt msg recv --target self` receives direct messages without widening into non-message events.
 - Add guardian tests proving `tt wait` / `tt take` return a live `guardian_pid`, and that a subsequent `tt wait` repairs a dead guardian for an existing owner.
 - Keep `TT_HARNESS_AGENT_ID` override as the explicit escape hatch.
 
@@ -192,7 +194,7 @@ This PR:
 
 Before merging the code-removal PR:
 
-- Start Claude receiver with `tt msg recv --follow --target self --json`.
+- Start Claude receiver with `tt events --follow --target self --json`.
 - Start Codex receiver the same way.
 - Send direct and broadcast messages both directions.
 - Verify `tt wait --timeout 110s --json`, `tt release --stdin`, and `tt assign <agent>` work from harness shell-outs.

--- a/skills/talking-stick/SKILL.md
+++ b/skills/talking-stick/SKILL.md
@@ -37,8 +37,9 @@ Useful commands:
 - `tt events . --after N --target any --json`
 - `tt notes add "..." --json`
 - `tt notes list --json`
+- `tt events --follow --target self --json`
 - `tt msg send <recipient|room> "..." --json`
-- `tt msg recv --follow --target self --json`
+- `tt msg recv --follow --target self --json` (messages-only fallback when an event-stream consumer is too broad)
 - `tt release . --stdin`
 - `tt assign <agent_id|next> . --stdin`
 - `tt take . --reason "..." --json`
@@ -59,6 +60,14 @@ tt join . --json
 
 Keep the returned room id and canonical path in mind, but keep using the workspace path (`.` is fine) for later CLI commands. If the workspace is nested, accept the resolved canonical path the CLI returns.
 
+Right after joining, start a background ambient receiver so direct messages and turn passes/reservations surface as soon as they happen instead of waiting for the next time you poll:
+
+```sh
+tt events --follow --target self --json
+```
+
+If your harness can stream a child process's stdout into the model's context (Claude Code's Monitor, Codex `attach`-style), this is enough — each line becomes an event you see mid-task. If your harness can only notice that a backgrounded command exits, use the polling fallback in §4.5. Without an ambient receiver, neither messages nor turn handoffs reach you between deliberate `tt wait` / `tt events` calls.
+
 ### 3. Wait Before Shared Work
 
 Before making shared edits or running owner-style actions, run:
@@ -76,7 +85,7 @@ Possible outcomes:
 - `takeover_available`: surface the reason and make takeover explicit
 - `closed`: stop and explain that the room is closed
 
-A successful `tt wait` or `tt take` starts an internal `tt guard` lease guardian and returns `guardian_pid` in JSON. Do not kill that guardian. If work may take minutes and the JSON response does not show a guardian, stop and inspect before starting long edits because the lease may expire while you work.
+A successful `tt wait` or `tt take` starts an internal `tt guard` lease guardian and returns `guardian_pid` in JSON. Verify the field is present and the pid is alive before you start a long edit; the guardian is what keeps your lease from expiring after the foreground `tt wait` process exits. If `guardian_pid` is missing or the pid is gone, stop, run `tt wait` again to repair the guardian (it will detect the existing ownership and respawn the guardian), and only then continue. Do not kill that guardian.
 
 ### 4. While Waiting
 
@@ -113,14 +122,20 @@ tt msg send <recipient|room> "message body" --json
 
 Recipient is a full `agent_id`, an unambiguous active display name, or the literal `room` for broadcast. `--interrupt` marks the message as time-sensitive; the receiver decides whether to act on it now.
 
-Receive with the mode your harness can observe:
+Receive with the mode your harness can observe. The recommended primary path is the unified event stream you started in §2:
 
 ```sh
-tt msg recv --follow --target self --json
-tt msg recv --wait --after <last_event_seq> --target self --json
+tt events --follow --target self --json
 ```
 
-Use `--follow` when the harness can monitor stdout from a long-running child. Use `--wait --after <last_event_seq>` when it can only notice that a background command completed. Restart with the returned cursor to resume.
+That streams direct messages, broadcasts, and turn passes/reservations as a single ordered feed — one JSON event per line. Use it whenever your harness can stream a child process's stdout into the model's context. If the harness can only notice that a backgrounded command exits, use the polling fallbacks:
+
+```sh
+tt events --wait --after <last_event_seq> --target self --json   # all event types
+tt msg recv --wait --after <last_event_seq> --target self --json # messages only
+```
+
+Restart with the returned cursor to resume. `tt msg recv --follow` still exists for harnesses that want a messages-only feed, but the event stream is preferred because turn handoffs use the same channel and a messages-only consumer silently misses them.
 
 Messages are public room events. Any room member can read them with `tt events --target any`. `to_agent_id` is routing, not an ACL.
 

--- a/skills/talking-stick/SKILL.md
+++ b/skills/talking-stick/SKILL.md
@@ -44,7 +44,7 @@ Useful commands:
 - `tt assign <agent_id|next> . --stdin`
 - `tt take . --reason "..." --json`
 
-Some workspaces may also have sibling receive processes running `tt msg recv --wait` or `tt msg recv --follow`; leave them alone unless the operator explicitly asks you to stop or restart them.
+Some workspaces may also have sibling receive processes running `tt events --follow`, `tt msg recv --wait`, or `tt msg recv --follow`; leave them alone unless the operator explicitly asks you to stop or restart them.
 
 If coordination is required and `tt` is unavailable, say so briefly and ask the user whether they want to install or enable Talking Stick first. Do not pretend coordination is active.
 

--- a/skills/talking-stick/SKILL.md
+++ b/skills/talking-stick/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talking-stick
-description: Use when working in a repo that coordinates multiple agent harnesses with Talking Stick (`tt` / `talking-stick`), or when the user asks you to avoid parallel work, wait your turn, pass structured handoffs, or coordinate with Claude, Codex, Gemini, or OpenCode in the same workspace. Also use when a workspace contains a `.talking-stick/` marker or when the MCP tools `list_rooms`, `join_path`, `leave_room`, `kick_member`, `wait_for_turn`, `heartbeat`, `release_stick`, `pass_stick`, `takeover_stick`, `get_room_state`, `get_room_events`, `send_message`, `wait_for_events`, `add_note`, or `list_notes` are available.
+description: Use when working in a repo that coordinates multiple agent harnesses with Talking Stick (`tt` / `talking-stick`), or when the user asks you to avoid parallel work, wait your turn, pass structured handoffs, or coordinate with Claude, Codex, Gemini, or OpenCode in the same workspace. Also use when a workspace contains a `.talking-stick/` marker.
 ---
 
 This skill teaches a harness how to behave in a Talking Stick workspace.
@@ -18,48 +18,56 @@ Use this skill when any of these are true:
 - the user mentions `talking-stick`, `tt`, handoffs, turn-taking, or avoiding parallel work
 - the repo is known to use Talking Stick coordination
 - a `.talking-stick/` marker exists
-- the Talking Stick MCP tools are available in the current harness
 
 Do not use this skill for ordinary single-agent work in repos that are not using Talking Stick.
 
 ## Workflow
 
-### 1. Check that Talking Stick is actually available
+### 1. Use The CLI
 
-Prefer the Talking Stick MCP tools when they are available. If they are not available but the `tt` CLI is on `PATH`, use the CLI instead (`tt list`, `tt join`, `tt leave`, `tt kick`, `tt wait`, `tt state`, `tt release`, `tt pass`, `tt assign`, `tt take`, `tt msg`). Do not treat missing MCP tools alone as proof that coordination is unavailable.
+Use the `tt` CLI for all Talking Stick coordination. Do not use old Talking Stick MCP tools for repo coordination, even if an older install exposes them; the CLI is the source of truth. Current updates should remove stale Talking Stick MCP registrations automatically.
+
+Useful commands:
+
+- `tt whoami --json`
+- `tt join . --json`
+- `tt wait . --timeout 110s --json`
+- `tt try . --json`
+- `tt state . --json`
+- `tt events . --after N --target any --json`
+- `tt notes add "..." --json`
+- `tt notes list --json`
+- `tt msg send <recipient|room> "..." --json`
+- `tt msg recv --follow --target self --json`
+- `tt release . --stdin`
+- `tt assign <agent_id|next> . --stdin`
+- `tt take . --reason "..." --json`
 
 Some workspaces may also have sibling receive processes running `tt msg recv --wait` or `tt msg recv --follow`; leave them alone unless the operator explicitly asks you to stop or restart them.
 
-If coordination is required and neither the MCP tools nor the `tt` CLI are available, say so briefly and ask the user whether they want to install or enable Talking Stick first. Do not pretend coordination is active.
+If coordination is required and `tt` is unavailable, say so briefly and ask the user whether they want to install or enable Talking Stick first. Do not pretend coordination is active.
 
 Human CLI runs silently keep already-installed Claude Code, Codex, and OpenCode skill copies/symlinks aligned with the bundled Talking Stick skill. This is best effort and only updates existing installs; Gemini skills are registry-managed and should be refreshed with `tt install gemini` when needed.
 
-### 2. Join the workspace room once
+### 2. Join The Workspace Room Once
 
-On the first substantial task in a Talking Stick workspace:
+On the first substantial task in a Talking Stick workspace, run:
 
-1. call `join_path` with the current workspace path
-2. keep the returned `room_id`
-3. note the returned policy, especially `heartbeatIntervalMs`
-
-If the workspace is nested, accept the resolved canonical path the server returns.
-
-### 3. Wait before doing shared work
-
-Before making shared edits or running owner-style actions, call `wait_for_turn`.
-
-Use the `room_id` returned by `join_path`. Do not pass the original filesystem path to `wait_for_turn`; path resolution belongs to `join_path`, and waiting must target the exact resolved room. This avoids ambiguity when a nested workspace resolves to an ancestor room or when multiple rooms could exist under the same tree.
-
-Keep the wait input minimal:
-
-```json
-{
-  "room_id": "<room_id from join_path>",
-  "max_wait_ms": 110000
-}
+```sh
+tt join . --json
 ```
 
-`max_wait_ms` is optional. Use the longest client-safe wait you can support: 110000 ms is a good MCP default when the harness can tolerate it; 180000 ms is fine only when the tool/client timeout is known to exceed that. If the call times out at the harness layer, fall back to a shorter value and call again. Do not send `cursor`, even if an old tool schema still exposes it; `wait_for_turn` is cursor-free, and resumable event replay belongs to `get_room_events`.
+Keep the returned room id and canonical path in mind, but keep using the workspace path (`.` is fine) for later CLI commands. If the workspace is nested, accept the resolved canonical path the CLI returns.
+
+### 3. Wait Before Shared Work
+
+Before making shared edits or running owner-style actions, run:
+
+```sh
+tt wait . --timeout 110s --json
+```
+
+Use the longest client-safe wait you can support. `110s` is a good default for active multi-agent coordination. If your harness has a shorter tool timeout, use the longest safe value and immediately wait again when it returns without granting the turn. Do not busy-loop with short waits.
 
 Possible outcomes:
 
@@ -68,91 +76,108 @@ Possible outcomes:
 - `takeover_available`: surface the reason and make takeover explicit
 - `closed`: stop and explain that the room is closed
 
-### 4. While waiting
+A successful `tt wait` or `tt take` starts an internal `tt guard` lease guardian and returns `guardian_pid` in JSON. Do not kill that guardian. If work may take minutes and the JSON response does not show a guardian, stop and inspect before starting long edits because the lease may expire while you work.
 
-**Prefer to run the wait in the background.** If your harness supports running a command or subtask in the background, launch the wait (`wait_for_turn` or `tt wait`) as a background process so your foreground stays free for other work — reading, planning, answering the operator — until your turn arrives. Blocking the whole harness on the wait defeats the point.
+### 4. While Waiting
 
-**Prefer wait cycles over scheduled wakeups.** A direct `wait_for_turn` long-poll keeps your cadence aligned with other agents and usually notices a released stick within the same cycle. Use scheduling only when your harness cannot keep a wait running in the background, or when it must return control between checks.
+Prefer to run `tt wait` in the background if your harness supports background commands. That keeps the foreground free for reading, planning, answering the operator, and watching OOB messages until your turn arrives.
 
-Wakeup pattern:
-
-1. Probe `wait_for_turn` with `max_wait_ms: 0`.
-2. If it returns `not_yet`, schedule a wakeup and return control to the harness. Keep active multi-agent wakeups tight: use 60-120 s, and never more than 120 s unless the operator explicitly pauses the room or the task is blocked outside the room.
-3. On wakeup, repeat from step 1.
-
-Scheduled wakeups are a fallback, not a reason to check in more slowly than agents using `wait_for_turn` directly. If your harness has neither background work nor wakeups, fall back to synchronous long-polls with the longest client-safe `max_wait_ms` from §3.
-
-Whether the wait runs in the foreground or the background, call it **once** with the client-safe `max_wait_ms` budget from above and let the server long-poll. When it returns without `your_turn`, call it again. Do not busy-loop with short waits — that generates log noise and burns cache without buying anything.
-
-Coordination is meant to be lightweight. `wait_for_turn` is the only long-running call you should make. Room-inspection RPCs (`get_room_state`, `get_room_events`) exist to answer specific questions ("who holds the stick right now?", "what was in my predecessor's handoff?") — do not call them on a timer or repeatedly just to check on another agent's progress. If you find yourself inspecting the room more than a few times per turn, stop; long-poll on `wait_for_turn` instead and trust the protocol.
+Prefer wait cycles over scheduled wakeups. A direct long-poll stays aligned with other agents and usually notices a released stick within the same cycle. Use scheduled wakeups only when your harness cannot keep a wait running in the background.
 
 If you do not have the stick:
 
 - do not make shared repo changes
 - do not silently race another harness
-- it is fine to read, plan, review, or help the user think — or any other work that does not mutate shared state
+- it is fine to read, plan, review, or help the user think
 - tell the user who currently holds or is reserved the turn when that is useful
 
-The wait is for *active* non-mutating work, not idle sleep. Re-read the holder's last handoff, follow up on its `artifacts[]`, investigate the area they are touching, and rethink the plan from your own angle. If you find something the holder should know — a missed invariant, a related bug, a sharper plan — leave a note with `add_note` rather than sitting on it until your next turn. Notes do not grant permission to edit shared files; they are observations and pointers, not coordination bypasses. The point: while you wait you can still move the work forward by feeding the holder, not by stalling.
+The wait is for active non-mutating work, not idle sleep. Re-read the holder's last handoff, follow up on its `artifacts[]`, investigate the area they are touching, and rethink the plan from your own angle. If you find something the holder should know, leave a durable note:
 
-When you do take the stick, first read the attached handoff and load any useful `artifacts[]`, then run `list_notes` once so you see what other members left for you. The owner's turn is the right place to act on a note, not to debate it with its author mid-turn.
+```sh
+tt notes add "Finding or pointer for the current/next holder." --json
+```
 
-### 4.5 Out-of-band messaging
+Room inspection exists to answer specific questions, not to poll. Use `tt state`, `tt events`, and `tt notes list` sparingly.
 
-The talking stick guarantees single-writer authority over shared workspace state. It is not a chat protocol. For transient signaling -- paging the holder, asking a quick question, or broadcasting awareness -- use messages.
+When you do take the stick, first read the attached handoff and load any useful `artifacts[]`, then run `tt notes list --json` once so you see what other members left for you.
 
-**Send.** `tt msg send <recipient> "<body>"` or MCP `send_message`. Recipient is a full `agent_id`, an unambiguous active display name, or the literal `room` for broadcast. `--interrupt` marks the message as time-sensitive; the receiver decides whether to act on it now.
+### 4.5 Out-Of-Band Messaging
 
-**Receive.** Use the receive mode your harness can observe. If it can monitor stdout from a long-running child, run `tt msg recv --follow`; each incoming event lands as one JSON line. If it can only notice that a background command completed, run `tt msg recv --wait --after <last_event_seq>`; it exits on the next matching batch, then you start it again with the returned cursor. Restart with `--after <last_event_seq>` to resume.
+The talking stick guarantees single-writer authority over shared workspace state. It is not a chat protocol. For transient signaling, use messages.
 
-**When to message vs note vs handoff.**
+Send:
 
-- **Message** when the exchange is conversational, ephemeral, and tied to processes that are currently online: design questions, "are you about to break X?", live coordination.
-- **Note** (`tt notes add`) when the artifact should outlive the moment: a finding the next holder should consider at handoff, or an observation that survives process churn.
-- **Handoff** (release/pass with a structured payload) when transferring work. Messages do not replace handoffs; they live alongside them.
+```sh
+tt msg send <recipient|room> "message body" --json
+```
 
-**Messages are not private.** Any room member can read any message via `get_room_events` or `tt events --follow --target any`. `to_agent_id` is routing, not an ACL.
+Recipient is a full `agent_id`, an unambiguous active display name, or the literal `room` for broadcast. `--interrupt` marks the message as time-sensitive; the receiver decides whether to act on it now.
 
-**Messages do not grant the stick.** A non-holder paging the holder does not gain write authority. The holder may act on the message immediately or defer until handoff.
+Receive with the mode your harness can observe:
 
-**Stay in the wait loop in parallel.** A `tt msg recv --wait` or `--follow` subprocess does not replace `wait_for_turn`. Keep waiting for your turn; messages are a side channel.
+```sh
+tt msg recv --follow --target self --json
+tt msg recv --wait --after <last_event_seq> --target self --json
+```
 
-### 5. While holding the stick
+Use `--follow` when the harness can monitor stdout from a long-running child. Use `--wait --after <last_event_seq>` when it can only notice that a background command completed. Restart with the returned cursor to resume.
 
-If the task may run longer than a few minutes, heartbeat periodically.
+Messages are public room events. Any room member can read them with `tt events --target any`. `to_agent_id` is routing, not an ACL.
 
-Use the cadence from `join_path.policy.heartbeatIntervalMs` when available. Do not invent your own cadence if the server already told you one.
+Messages do not grant the stick. A non-holder paging the holder does not gain write authority. Keep waiting for your turn; messages are only a side channel.
 
-**Holding the stick is for active work.** The moment you stop actively editing, reasoning through edits, or asking the operator a blocking question, release or pass. Do not idle-hold the room while waiting on long verification, non-blocking operator input, CI, or any other pause where another harness could make progress.
+### 5. While Holding The Stick
 
-### 6. Takeover is explicit
+Holding the stick is for active work. The moment you stop actively editing, reasoning through edits, or asking the operator a blocking question, release or assign the turn. Do not idle-hold the room while waiting on long verification, non-blocking operator input, CI, or any other pause where another harness could make progress.
 
-If `wait_for_turn` reports `takeover_available`:
+The `tt guard` process spawned by `tt wait` keeps the lease alive during active work. Later owner commands such as `tt release`, `tt assign`, and `tt take` must run under the same harness identity. If identity is ambiguous, use the exact active id with `TT_HARNESS_AGENT_ID=<agent_id>`.
+
+### 6. Takeover Is Explicit
+
+If `tt wait` reports `takeover_available`:
 
 - explain why takeover is available (`owner_timeout`, `owner_gone`, `claim_timeout`, `recipient_gone`)
 - do not silently take over just because it is possible
-- if takeover is chosen, call `takeover_stick`
-- after takeover, call `get_room_events` so you can reconstruct the last handoff before touching code
+- if takeover is chosen, run `tt take . --reason "..." --json`
+- after takeover, run `tt events . --target any --json` so you can reconstruct the last handoff before touching code
 
-If the operator explicitly tells you to take over despite a reservation or live owner, use the CLI path when available: `tt take --operator-requested --reason "<operator requested takeover>"`. Do not invent this override yourself; it is for direct operator intervention.
+If the operator explicitly tells you to take over despite a reservation or live owner, use:
 
-### 7. Finish with a real handoff
+```sh
+tt take . --operator-requested --reason "operator requested takeover" --json
+```
 
-When you are done with your turn, default to `release_stick`.
+Do not invent this override yourself; it is for direct operator intervention.
 
-**Default to `release_stick`.** Releasing lets the server pick the next fair waiter: a recent waiter that is new or has gone longest without holding the stick. If the best-known candidate is between wait polls, the room can briefly stay claimable instead of pinning a stale reservation. This keeps the room open instead of silently turning agent-to-agent handoffs into a duopoly.
+### 7. Finish With A Real Handoff
 
-Use `pass_stick` only when you have a concrete reason a specific named member must go next:
+When you are done with your turn, default to releasing:
+
+```sh
+tt release . --stdin <<'JSON'
+{
+  "status": "Updated the CLI-only coordination plan and the bundled skill so harnesses use tt subprocesses for join, wait, OOB messaging, notes, and handoffs.",
+  "next_action": "Review the plan and then start the code-removal pass.",
+  "artifacts": [
+    {
+      "path": "docs/plans/2026-05-05-cli-only-coordination.md",
+      "role": "review",
+      "note": "CLI-only migration plan."
+    }
+  ]
+}
+JSON
+```
+
+Use `tt assign <agent_id> . --stdin` only when a specific named member must go next:
 
 - they have unique context the next step requires
 - they hold a credential or capability others lack
 - the operator explicitly addressed the work to them
 
-Otherwise release. Ping-ponging `pass_stick` between two agents is an antipattern because it can lock humans out of their own room.
+Otherwise release. Pinning turns between two agents is an antipattern because it can lock humans out of their own room.
 
-Always include a non-empty handoff.
-
-**Keep handoffs tight.** Handoffs are persisted in the event log and re-read on claims. Aim for roughly 150-300 words of `status`; reference commits by SHA instead of restating diffs, and use `artifacts[]` with path, line range, and role instead of pasting code. The handoff is the headline; long-form context belongs in `docs/` or a note.
+Always include a non-empty handoff. Keep it tight: aim for roughly 150-300 words of `status`; reference commits by SHA instead of restating diffs, and use `artifacts[]` with path and role instead of pasting code.
 
 Minimum handoff quality:
 
@@ -161,58 +186,33 @@ Minimum handoff quality:
 
 Add `artifacts`, `open_questions`, and `do_not` when they will save the next harness real time or prevent rework.
 
-Example:
+### 8. After Release, Stay In The Loop
 
-```json
-{
-  "status": "Added the MCP smoke test and verified it against two clients sharing one SQLite database.",
-  "next_action": "Run the same handoff path through the human CLI and confirm pass/release behavior matches the MCP flow.",
-  "artifacts": [
-    {
-      "path": "tests/mcp-smoke.test.ts",
-      "role": "review",
-      "note": "End-to-end MCP adapter smoke coverage."
-    }
-  ],
-  "open_questions": [
-    "Should tt install default to copy or link for local development?"
-  ]
-}
-```
-
-**`pass_stick` requires the target to be an active room member.** If the intended recipient's harness session has ended and they show as `inactive` in `get_room_state.members`, `pass_stick` can return `unknown_member`. Use `release_stick` instead; the next fair waiter can claim through the normal sequence path.
-
-Remember that the operator can join their own room as `human:<user>`. Default behavior should leave room for them to claim turns naturally; releasing rather than passing keeps that door open.
-
-### 8. After passing or releasing, stay in the loop
-
-**The default after `release_stick` or `pass_stick` is to re-enter the wait loop and keep waiting until your next turn arrives.** Do not stop and ask the operator whether they want you back in the loop. Do not treat a handoff as end-of-session. In a multi-agent workspace, the expectation is: work on your turn, hand off, wait for your next turn, repeat.
-
-Stopping to ask questions after every handoff defeats the coordination protocol — the operator wired you into a room so that you *would* keep showing up without being asked.
+The default after `tt release` or `tt assign` is to re-enter the wait loop and keep waiting until your next turn arrives. Do not stop and ask the operator whether they want you back in the loop. Do not treat a handoff as end-of-session.
 
 Exit the wait loop only when one of these is true:
 
-- the shared task is explicitly finished (the operator said so, or the final handoff marks the work complete)
+- the shared task is explicitly finished
 - you are the only active member and there is no one to hand off to
-- the operator gives a direct redirect or stop ("that's enough," "drop out of the room," a new unrelated task, etc.)
+- the operator gives a direct redirect or stop
 
-In every other case: after `release_stick` or `pass_stick`, go straight back into the wait loop (ideally backgrounded — see §4).
+In every other case, after `tt release` or `tt assign`, go straight back into `tt wait . --timeout 110s --json`.
 
-If the operator tells you to drop out of coordination, call `leave_room` or `tt leave`. Rooms with no active members are deleted instead of kept as history, and long-idle rooms may be purged on later invocations.
+If the operator tells you to drop out of coordination, run `tt leave . --json`. Rooms with no active members are deleted instead of kept as history, and long-idle rooms may be purged on later invocations.
 
-If the room state shows ghost members from past sessions whose processes are gone (visible as `inactive last seen ...` in `tt state`), call `kick_member` / `tt kick <agent_id>` to evict them. This is the right tool when liveness has already decided the target is dead — pass `force: true` only when the operator explicitly tells you to remove a still-active member.
+If the room state shows ghost members from past sessions whose processes are gone, run `tt kick <agent_id> . --json` to evict them. Use `--force` only when the operator explicitly tells you to remove a still-active member.
 
-## Recovery and Inspection
+## Recovery And Inspection
 
 Use these reads when you need context:
 
-- `list_rooms`: discover active rooms under a path
-- `leave_room`: explicitly remove your membership from a room
-- `kick_member`: evict an idle member whose process is gone (use `force: true` only on operator instruction)
-- `get_room_state`: authoritative current room projection
-- `get_room_events`: replay recent claims, releases, passes, and takeovers
+- `tt list . --json`: discover active rooms under a path
+- `tt state . --json`: authoritative current room projection
+- `tt events . --target any --json`: replay recent claims, releases, assignments, messages, and takeovers
+- `tt notes list --json`: list durable notes
+- `tt whoami --explain`: inspect identity resolution
 
-Prefer `get_room_state` over guessing from local memory when ownership may have changed.
+Prefer `tt state` over guessing from local memory when ownership may have changed.
 
 ## Behavior Priorities
 


### PR DESCRIPTION
## Summary
- Adds a CLI-only coordination plan that removes MCP as the harness integration path.
- Updates the bundled Talking Stick skill to use tt CLI commands for join, wait, OOB messaging, notes, handoffs, and takeover.
- Captures update-time cleanup for stale Talking Stick MCP registrations across supported harnesses.

## Validation
- git diff --check
- git diff --cached --check