### PR TITLE
Harden CLI-only Stage 2 identity and receive coverage

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -245,8 +245,6 @@ function resolveHarnessSessionId(
   inspector: ProcessInspector
 ): string {
   if (signal.sessionId) return `harness:${signal.sessionId}`;
-  const terminalId = resolveTerminalSessionId(env);
-  if (terminalId) return terminalId;
 
   const harnessRoot = findHarnessRootInAncestry(
     signal.harness,
@@ -257,6 +255,9 @@ function resolveHarnessSessionId(
   if (harnessRoot) {
     return `pid:${harnessRoot.pid}@${harnessRoot.startTime}`;
   }
+
+  const terminalId = resolveTerminalSessionId(env);
+  if (terminalId) return terminalId;
 
   if (parentInspection?.startTime) {
     return `pid:${parentPid}@${parentInspection.startTime}`;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -464,6 +464,90 @@ describe("tt turn commands", () => {
     expect(passed.reserved_for).toBe("human:next");
   });
 
+  test("tt wait returns a live guardian pid", async () => {
+    const { project } = setupIsolatedCli(tempDirs);
+    let guardianPid: number | undefined;
+
+    try {
+      await captureStdout(["join", project, "--agent", "human:worker"]);
+      const waitOut = await captureStdout([
+        "wait",
+        project,
+        "--timeout",
+        "0ms",
+        "--agent",
+        "human:worker",
+        "--json"
+      ]);
+      const waitResult = JSON.parse(waitOut) as {
+        status: string;
+        guardian_pid?: number;
+      };
+      guardianPid = waitResult.guardian_pid;
+
+      expect(waitResult.status).toBe("your_turn");
+      expect(guardianPid).toEqual(expect.any(Number));
+      expect(isPidAlive(guardianPid as number)).toBe(true);
+    } finally {
+      await releaseIfHeld(project, "human:worker");
+      killPidIfAlive(guardianPid);
+    }
+  });
+
+  test("tt wait repairs a missing guardian for an existing owner", async () => {
+    const { project } = setupIsolatedCli(tempDirs);
+    let firstGuardianPid: number | undefined;
+    let repairedGuardianPid: number | undefined;
+
+    try {
+      await captureStdout(["join", project, "--agent", "human:worker"]);
+      const firstWaitOut = await captureStdout([
+        "wait",
+        project,
+        "--timeout",
+        "0ms",
+        "--agent",
+        "human:worker",
+        "--json"
+      ]);
+      const firstWait = JSON.parse(firstWaitOut) as {
+        status: string;
+        guardian_pid: number;
+      };
+      firstGuardianPid = firstWait.guardian_pid;
+      expect(firstWait.status).toBe("your_turn");
+      expect(isPidAlive(firstGuardianPid)).toBe(true);
+
+      process.kill(firstGuardianPid, "SIGTERM");
+      await waitForPidGone(firstGuardianPid);
+
+      const secondWaitOut = await captureStdout([
+        "wait",
+        project,
+        "--timeout",
+        "0ms",
+        "--agent",
+        "human:worker",
+        "--json"
+      ]);
+      const secondWait = JSON.parse(secondWaitOut) as {
+        status: string;
+        reason: string;
+        guardian_pid: number;
+      };
+      repairedGuardianPid = secondWait.guardian_pid;
+
+      expect(secondWait.status).toBe("your_turn");
+      expect(secondWait.reason).toBe("already_owner");
+      expect(repairedGuardianPid).toEqual(expect.any(Number));
+      expect(isPidAlive(repairedGuardianPid)).toBe(true);
+    } finally {
+      await releaseIfHeld(project, "human:worker");
+      killPidIfAlive(firstGuardianPid);
+      killPidIfAlive(repairedGuardianPid);
+    }
+  });
+
   test("tt assign next resolves the fair active recipient", async () => {
     const { project } = setupIsolatedCli(tempDirs);
 
@@ -1343,6 +1427,33 @@ describe("tt msg", () => {
     );
   });
 
+  test("tt msg recv stays messages-only when a turn is passed", async () => {
+    const { project } = setupIsolatedCli(tempDirs);
+    const roomId = seedCliRoomMembers(project, [
+      { agent_id: "human:owner", display_name: "owner" },
+      { agent_id: "human:receiver", display_name: "receiver" }
+    ]);
+
+    const recvPromise = captureStdout([
+      "msg",
+      "recv",
+      "--wait",
+      "--timeout",
+      "100ms",
+      "--agent",
+      "human:receiver",
+      "--path",
+      project,
+      "--json"
+    ]);
+    const passPromise = delay(25).then(() =>
+      passCliTestTurn(roomId, "human:owner", "human:receiver")
+    );
+
+    expect(await recvPromise).toBe("");
+    await passPromise;
+  });
+
   test("tt events --wait filters event types and emits JSON lines", async () => {
     const { project } = setupIsolatedCli(tempDirs);
     const roomId = seedCliRoomMembers(project, [
@@ -1413,6 +1524,154 @@ describe("tt msg", () => {
       from_agent_id: "human:sender",
       to_agent_id: "human:receiver",
       payload: { body: "not for observer" }
+    });
+  });
+
+  test("tt events --follow --target self sees direct messages and turn handoffs", async () => {
+    const { project } = setupIsolatedCli(tempDirs);
+    const roomId = seedCliRoomMembers(project, [
+      { agent_id: "human:owner", display_name: "owner" },
+      { agent_id: "human:receiver", display_name: "receiver" }
+    ]);
+    const watcher = spawnCliProcess([
+      "events",
+      project,
+      "--follow",
+      "--after",
+      "0",
+      "--target",
+      "self",
+      "--timeout",
+      "50ms",
+      "--agent",
+      "human:receiver",
+      "--json"
+    ]);
+
+    sendCliTestMessage(roomId, "human:owner", "human:receiver", "direct");
+    await passCliTestTurn(roomId, "human:owner", "human:receiver");
+    const lines = await waitForStdoutLines(watcher, 2);
+    const events = lines.map((line) => JSON.parse(line));
+
+    const closePromise = waitForProcessClose(watcher.child);
+    watcher.child.kill("SIGTERM");
+    const close = await closePromise;
+
+    expect(close).toMatchObject({ code: 0, signal: null });
+    expect(events.map((event) => event.event_type)).toEqual([
+      "message_sent",
+      "pass"
+    ]);
+    expect(events[0]).toMatchObject({
+      from_agent_id: "human:owner",
+      to_agent_id: "human:receiver",
+      payload: { body: "direct" }
+    });
+    expect(events[1]).toMatchObject({
+      from_agent_id: "human:owner",
+      to_agent_id: "human:receiver",
+      handoff: {
+        status: "Owner is passing.",
+        next_action: "Receiver should claim."
+      }
+    });
+  });
+
+  test("tt events --target self uses harness identity without TT_HARNESS_AGENT_ID", async () => {
+    const { project } = setupIsolatedCli(tempDirs);
+    const harnessEnv = {
+      CODEX_THREAD_ID: "stage2-thread"
+    };
+    const joinOut = await runCliProcess([
+      "join",
+      project,
+      "--json"
+    ], "", harnessEnv);
+    const joined = JSON.parse(joinOut.stdout) as {
+      agent_id: string;
+      room_id: string;
+    };
+
+    const service = new TalkingStickService();
+    try {
+      const sender = deriveHumanCliIdentity({
+        agentId: "human:sender",
+        displayName: "sender"
+      });
+      const owner = deriveHumanCliIdentity({
+        agentId: "human:owner",
+        displayName: "owner"
+      });
+      service.joinPath({
+        agent_id: sender.agent_id,
+        context_path: project,
+        process_metadata: sender.process_metadata
+      });
+      service.joinPath({
+        agent_id: owner.agent_id,
+        context_path: project,
+        process_metadata: owner.process_metadata
+      });
+      service.sendMessage({
+        agent_id: sender.agent_id,
+        room_id: joined.room_id,
+        to_agent_id: joined.agent_id,
+        body: "direct to harness"
+      });
+
+      const turn = await service.waitForTurn({
+        agent_id: owner.agent_id,
+        room_id: joined.room_id,
+        max_wait_ms: 0
+      });
+      expect(turn.status).toBe("your_turn");
+      if (turn.status !== "your_turn") {
+        throw new Error(`Expected owner turn, got ${turn.status}`);
+      }
+      service.passStick({
+        agent_id: owner.agent_id,
+        room_id: joined.room_id,
+        lease_id: turn.lease_id,
+        expected_turn_id: turn.turn_id,
+        to_agent_id: joined.agent_id,
+        handoff: {
+          status: "Owner is passing.",
+          next_action: "Harness should claim."
+        }
+      });
+    } finally {
+      service.close();
+    }
+
+    const eventsOut = await runCliProcess([
+      "events",
+      project,
+      "--wait",
+      "--after",
+      "0",
+      "--target",
+      "self",
+      "--timeout",
+      "100ms",
+      "--json"
+    ], "", harnessEnv);
+    const events = parseJsonLines(eventsOut.stdout);
+
+    expect(joined.agent_id).toMatch(/^codex:/);
+    expect(events.map((event) => event.event_type)).toEqual([
+      "message_sent",
+      "pass"
+    ]);
+    expect(events[0]).toMatchObject({
+      to_agent_id: joined.agent_id,
+      payload: { body: "direct to harness" }
+    });
+    expect(events[1]).toMatchObject({
+      to_agent_id: joined.agent_id,
+      handoff: {
+        status: "Owner is passing.",
+        next_action: "Harness should claim."
+      }
     });
   });
 });
@@ -1535,6 +1794,39 @@ function sendCliTestMessage(
   }
 }
 
+async function passCliTestTurn(
+  roomId: string,
+  ownerAgentId: string,
+  targetAgentId: string
+): Promise<void> {
+  const service = new TalkingStickService();
+  try {
+    const turn = await service.waitForTurn({
+      agent_id: ownerAgentId,
+      room_id: roomId,
+      max_wait_ms: 0
+    });
+    expect(turn.status).toBe("your_turn");
+    if (turn.status !== "your_turn") {
+      throw new Error(`Expected owner turn, got ${turn.status}`);
+    }
+
+    service.passStick({
+      agent_id: ownerAgentId,
+      room_id: roomId,
+      lease_id: turn.lease_id,
+      expected_turn_id: turn.turn_id,
+      to_agent_id: targetAgentId,
+      handoff: {
+        status: "Owner is passing.",
+        next_action: "Receiver should claim."
+      }
+    });
+  } finally {
+    service.close();
+  }
+}
+
 function parseJsonLines(output: string): any[] {
   return output
     .split("\n")
@@ -1548,7 +1840,11 @@ interface SpawnedCliProcess {
   stderr: () => string;
 }
 
-function spawnCliProcess(argv: string[], stdin = ""): SpawnedCliProcess {
+function spawnCliProcess(
+  argv: string[],
+  stdin = "",
+  extraEnv: NodeJS.ProcessEnv = {}
+): SpawnedCliProcess {
   const child = spawn(
     process.execPath,
     ["--import", "tsx", "src/cli.ts", ...argv],
@@ -1556,6 +1852,7 @@ function spawnCliProcess(argv: string[], stdin = ""): SpawnedCliProcess {
       cwd: process.cwd(),
       env: {
         ...process.env,
+        ...extraEnv,
         TALKING_STICK_DISABLE_SKILL_SYNC: "1"
       },
       stdio: "pipe"
@@ -1581,9 +1878,10 @@ function spawnCliProcess(argv: string[], stdin = ""): SpawnedCliProcess {
 
 async function runCliProcess(
   argv: string[],
-  stdin: string
+  stdin: string,
+  extraEnv: NodeJS.ProcessEnv = {}
 ): Promise<{ stdout: string; stderr: string }> {
-  const processState = spawnCliProcess(argv, stdin);
+  const processState = spawnCliProcess(argv, stdin, extraEnv);
   const close = await waitForProcessClose(processState.child);
   if (close.code !== 0) {
     throw new Error(
@@ -1641,6 +1939,52 @@ async function waitForFirstStdoutLine(
   });
 }
 
+async function waitForStdoutLines(
+  processState: SpawnedCliProcess,
+  count: number,
+  timeoutMs = 3000
+): Promise<string[]> {
+  const existing = stdoutLines(processState.stdout());
+  if (existing.length >= count) {
+    return existing.slice(0, count);
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      processState.child.kill("SIGKILL");
+      reject(
+        new Error(
+          `Timed out waiting for ${count} stdout lines. stderr=${processState.stderr()}`
+        )
+      );
+    }, timeoutMs);
+    const onData = () => {
+      const lines = stdoutLines(processState.stdout());
+      if (lines.length >= count) {
+        cleanup();
+        resolve(lines.slice(0, count));
+      }
+    };
+    const onClose = () => {
+      cleanup();
+      reject(
+        new Error(
+          `CLI process closed before ${count} stdout lines. stderr=${processState.stderr()}`
+        )
+      );
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      processState.child.stdout.off("data", onData);
+      processState.child.off("close", onClose);
+    };
+
+    processState.child.stdout.on("data", onData);
+    processState.child.once("close", onClose);
+  });
+}
+
 async function waitForProcessClose(
   child: ChildProcessWithoutNullStreams,
   timeoutMs = 3000
@@ -1664,9 +2008,67 @@ async function waitForProcessClose(
   });
 }
 
+async function releaseIfHeld(project: string, agentId: string): Promise<void> {
+  try {
+    await captureStdout([
+      "release",
+      project,
+      "--agent",
+      agentId,
+      "--status",
+      "Cleanup release.",
+      "--next-action",
+      "Continue.",
+      "--json"
+    ]);
+  } catch {
+    // Best-effort test cleanup; the assertion that matters already happened.
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killPidIfAlive(pid: number | undefined): void {
+  if (pid === undefined || !isPidAlive(pid)) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Best-effort test cleanup.
+  }
+}
+
+async function waitForPidGone(pid: number, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return;
+    }
+    await delay(25);
+  }
+  throw new Error(`Timed out waiting for pid ${pid} to exit.`);
+}
+
 function firstLine(output: string): string | null {
-  const line = output.split("\n").find((item) => item.length > 0);
+  const line = stdoutLines(output)[0];
   return line ?? null;
+}
+
+function stdoutLines(output: string): string[] {
+  return output.split("\n").filter((item) => item.length > 0);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function captureStdout(argv: string[]): Promise<string> {

--- a/tests/identity.test.ts
+++ b/tests/identity.test.ts
@@ -379,6 +379,37 @@ describe("deriveHarnessCliIdentity", () => {
     });
     expect(a!.agent_id).not.toBe(b!.agent_id);
   });
+
+  test("prefers harness root ancestry over terminal ids when the harness has no session id", () => {
+    const ancestryInspector = fakeInspector({
+      8000: { startTime: "Thu Apr 23 13:50:00 2026", command: "claude", ppid: 1 },
+      9000: { startTime: "Thu Apr 23 14:00:00 2026", command: "bash", ppid: 8000 },
+      9001: { startTime: "Thu Apr 23 14:05:00 2026", command: "bash", ppid: 8000 }
+    });
+
+    const first = deriveHarnessCliIdentity({
+      env: {
+        CLAUDECODE: "1",
+        ITERM_SESSION_ID: "w0t0p0:first"
+      },
+      username: "alice",
+      parentPid: 9000,
+      hostId: "test-host",
+      inspector: ancestryInspector
+    });
+    const second = deriveHarnessCliIdentity({
+      env: {
+        CLAUDECODE: "1",
+        ITERM_SESSION_ID: "w0t0p0:second"
+      },
+      username: "alice",
+      parentPid: 9001,
+      hostId: "test-host",
+      inspector: ancestryInspector
+    });
+
+    expect(first!.agent_id).toBe(second!.agent_id);
+  });
 });
 
 describe("CLI and MCP identity unification", () => {

--- a/tests/skill-install.test.ts
+++ b/tests/skill-install.test.ts
@@ -104,9 +104,9 @@ describe("talking-stick skill install", () => {
 
     const target = path.join(tempRoot, ".codex", "skills", "talking-stick");
     expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
-    expect(fs.readFileSync(path.join(target, "SKILL.md"), "utf8")).toContain(
-      "### 4.5 Out-of-band messaging"
-    );
+    const skill = fs.readFileSync(path.join(target, "SKILL.md"), "utf8");
+    expect(skill).toContain("### 4.5 Out-Of-Band Messaging");
+    expect(skill).toContain("tt events --follow --target self --json");
   });
 
   test("skips skill install when the harness config directory is missing", async () => {
@@ -183,9 +183,9 @@ describe("talking-stick skill install", () => {
 
     const target = path.join(tempRoot, ".claude", "skills", "talking-stick");
     expect(fs.lstatSync(target).isSymbolicLink()).toBe(false);
-    expect(fs.readFileSync(path.join(target, "SKILL.md"), "utf8")).toContain(
-      "### 4.5 Out-of-band messaging"
-    );
+    const skill = fs.readFileSync(path.join(target, "SKILL.md"), "utf8");
+    expect(skill).toContain("### 4.5 Out-Of-Band Messaging");
+    expect(skill).toContain("tt events --follow --target self --json");
   });
 
   test("syncInstalledSkills updates an existing copied skill without installing missing harnesses", () => {


### PR DESCRIPTION
## Summary
- Prefer harness-root ancestry over terminal ids when deriving CLI harness identity without a stable session id.
- Add child-process coverage for `tt events --target self` receiving direct messages and turn handoffs without `TT_HARNESS_AGENT_ID`.
- Add guardian coverage proving `tt wait` returns a live guardian pid and repairs a missing guardian for an existing owner.
- Update skill-install assertions for the new ambient receiver guidance.

## Validation
- npm test -- tests/identity.test.ts
- npm test -- tests/cli.test.ts tests/identity.test.ts
- npm test -- tests/skill-install.test.ts tests/cli.test.ts tests/identity.test.ts
- npm run typecheck
- npm test