### PR TITLE
Add CLI-only migration release notes

### DIFF
--- a/docs/releases/0.3.0.md
+++ b/docs/releases/0.3.0.md
@@ -1,0 +1,71 @@
+# Talking Stick 0.3.0
+
+Date: 2026-05-05
+
+Breaking release that makes the `tt` CLI the only harness integration contract.
+Talking Stick no longer installs or serves an MCP adapter. Agents coordinate by
+running `tt` subprocesses for join/wait/handoff, notes, messages, and event
+receive.
+
+## Breaking Changes
+
+### MCP server surface removed
+
+Removed the MCP stdio server implementation, `tt mcp` command registration,
+MCP-specific tests, and the `@modelcontextprotocol/sdk` dependency. The package
+exports no MCP server helpers. `tt --help` no longer advertises MCP startup, and
+`tt install` no longer writes MCP server config.
+
+### `tt install` is skill-only
+
+`tt install <harness>` now installs or refreshes the bundled
+`talking-stick` skill for Claude Code, Codex, Gemini, and OpenCode. The older
+`tt install-skill` and `tt uninstall-skill` command surface is gone because
+`tt install` / `tt uninstall` own skill installation directly.
+
+## Migration
+
+### Stale MCP cleanup
+
+Updates remove stale Talking Stick MCP registrations from older installs instead
+of keeping the broken dual integration path alive.
+
+Cleanup runs from:
+
+- package postinstall when installed under `node_modules/talking-stick`
+- `tt self-update` after the package manager command returns
+- the first normal installed-package `tt` invocation after a package-version
+  change
+- explicit `tt install` and `tt uninstall`
+
+Each run appends JSONL audit entries to
+`${TALKING_STICK_DATA_DIR}/update-migrations.log`. OpenCode cleanup is
+shape-strict: only the canonical `mcp.talking-stick` entry with `["tt", "mcp"]`
+is removed. Claude Code, Codex, and Gemini use their native `mcp remove`
+commands for the old `talking-stick` server name.
+
+## CLI-Only Runtime
+
+The bundled skill now teaches harnesses to start
+`tt events --follow --target self --json` as the ambient receiver, keep
+`tt wait . --timeout 110s --json` running for turn ownership, and verify the
+returned guardian pid before long edits. `tt msg recv` remains a messages-only
+fallback; the unified event stream is the primary OOB path because turn
+handoffs and messages share one ordered feed.
+
+CLI identity resolution now prefers stable harness ancestry over transient
+terminal ids when no explicit harness session id exists. That keeps repeated
+shell-outs from one harness attached to the same room member.
+
+## Verification
+
+```bash
+npm run typecheck
+npm test
+npm run build
+git diff --check
+```
+
+Stage validation covered the migration runner, install/uninstall/self-update
+cleanup wiring, child-process CLI receive behavior, guardian repair, full-suite
+tests after MCP deletion, and built `dist/` output with no MCP/server files.


### PR DESCRIPTION
## Summary
- add `docs/releases/0.3.0.md` documenting the CLI-only breaking migration
- capture MCP server removal, skill-only install behavior, stale MCP cleanup paths, OOB receive guidance, and validation

## Validation
- `git diff --check`
- `npm run typecheck`
